### PR TITLE
environment types updated, addresses issue #8

### DIFF
--- a/sources/tsl-apple-cloudkit.d.ts
+++ b/sources/tsl-apple-cloudkit.d.ts
@@ -1890,7 +1890,7 @@ declare module CloudKit
          * Possible values are `DEVELOPMENT_ENVIRONMENT` and
          * `PRODUCTION_ENVIRONMENT`.
          */
-        apnsEnvironment?: ( 'DEVELOPMENT_ENVIRONMENT' | 'PRODUCTION_ENVIRONMENT' );
+        apnsEnvironment?: ( 'DEVELOPMENT_ENVIRONMENT' | 'PRODUCTION_ENVIRONMENT' | 'development' | 'production' );
 
         /**
          * The string that identifies the app’s container. This key is
@@ -1904,7 +1904,7 @@ declare module CloudKit
          * Possible values are `DEVELOPMENT_ENVIRONMENT` and
          * `PRODUCTION_ENVIRONMENT`.
          */
-        environment: ( 'DEVELOPMENT_ENVIRONMENT' | 'PRODUCTION_ENVIRONMENT' );
+        environment: ( 'DEVELOPMENT_ENVIRONMENT' | 'PRODUCTION_ENVIRONMENT' | 'development' | 'production' );
 
         /**
          * The server-to-server authentication key and related properties.
@@ -1935,7 +1935,7 @@ declare module CloudKit
          * Possible values are `DEVELOPMENT_ENVIRONMENT` and
          * `PRODUCTION_ENVIRONMENT`.
          */
-        apnsEnvironment?: ( 'DEVELOPMENT_ENVIRONMENT' | 'PRODUCTION_ENVIRONMENT' );
+        apnsEnvironment?: ( 'DEVELOPMENT_ENVIRONMENT' | 'PRODUCTION_ENVIRONMENT' | 'development' | 'production' );
 
         /**
          * The string that identifies the app’s container. This key is
@@ -1949,7 +1949,7 @@ declare module CloudKit
          * Possible values are `DEVELOPMENT_ENVIRONMENT` and
          * `PRODUCTION_ENVIRONMENT`.
          */
-        environment: ( 'DEVELOPMENT_ENVIRONMENT' | 'PRODUCTION_ENVIRONMENT' );
+        environment: ( 'DEVELOPMENT_ENVIRONMENT' | 'PRODUCTION_ENVIRONMENT' | 'development' | 'production' );
 
         /**
          * The server-to-server authentication key and related properties.


### PR DESCRIPTION
The environment types for the CloudKit class are set to
'DEVELOPMENT_ENVIRONMENT' | 'PRODUCTION_ENVIRONMENT'

when it should be
'development' | 'production'

https://cdn.apple-cloudkit.com/cloudkit-catalog/#readme/CloudKit-on-the-web shows the environment variable being used for development

I added the two new types without removing the old ones since I don't know how they are being used.